### PR TITLE
bring back trim_trailing_whitespace and insert_final_newline support

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -12,7 +12,7 @@
   </change-notes>
 
   <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="120.000" until-build="135.9999"/>
+  <idea-version since-build="134.543"/>
 
   <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->

--- a/src/org/editorconfig/configmanagement/EditorSettingsManager.java
+++ b/src/org/editorconfig/configmanagement/EditorSettingsManager.java
@@ -48,7 +48,7 @@ public class EditorSettingsManager extends FileDocumentManagerAdapter {
     }
 
     private static void applySettings(VirtualFile file) {
-        if (!file.isInLocalFileSystem()) return;
+        if (file == null || !file.isInLocalFileSystem()) return;
         // Get editorconfig settings
         final String filePath = file.getCanonicalPath();
         final SettingsProviderComponent settingsProvider = SettingsProviderComponent.getInstance();

--- a/src/org/editorconfig/configmanagement/EditorSettingsManager.java
+++ b/src/org/editorconfig/configmanagement/EditorSettingsManager.java
@@ -1,0 +1,80 @@
+package org.editorconfig.configmanagement;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.ex.EditorSettingsExternalizable;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;
+import com.intellij.openapi.fileEditor.impl.TrailingSpacesStripper;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.editorconfig.Utils;
+import org.editorconfig.core.EditorConfig;
+import org.editorconfig.plugincomponents.SettingsProviderComponent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EditorSettingsManager extends FileDocumentManagerAdapter {
+    // Handles the following EditorConfig settings:
+    private static final String trimTrailingWhitespaceKey = "trim_trailing_whitespace";
+    private static final String insertFinalNewlineKey = "insert_final_newline";
+    private static final Map<String, String> trimMap;
+    static {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("true", EditorSettingsExternalizable.STRIP_TRAILING_SPACES_WHOLE);
+        map.put("false", EditorSettingsExternalizable.STRIP_TRAILING_SPACES_NONE);
+        trimMap = Collections.unmodifiableMap(map);
+    }
+    private static final Map<String, Boolean> newlineMap;
+    static {
+        Map<String, Boolean> map = new HashMap<String, Boolean>();
+        map.put("true", Boolean.TRUE);
+        map.put("false", Boolean.FALSE);
+        newlineMap = Collections.unmodifiableMap(map);
+    }
+
+    private static final Logger LOG = Logger.getInstance("#org.editorconfig.configmanagement.EditorSettingsManager");
+
+    @Override
+    public void beforeDocumentSaving(@NotNull Document document) {
+        // This is fired when any document is saved, regardless of whether it is part of a save-all or
+        // a save-one operation
+        final VirtualFile file = FileDocumentManager.getInstance().getFile(document);
+        applySettings(file);
+    }
+
+    private static void applySettings(VirtualFile file) {
+        if (!file.isInLocalFileSystem()) return;
+        // Get editorconfig settings
+        final String filePath = file.getCanonicalPath();
+        final SettingsProviderComponent settingsProvider = SettingsProviderComponent.getInstance();
+        final List<EditorConfig.OutPair> outPairs = settingsProvider.getOutPairs(filePath);
+        // Apply trailing spaces setting
+        final String trimTrailingWhitespace = Utils.configValueForKey(outPairs, trimTrailingWhitespaceKey);
+        applyConfigValueToUserData(file, TrailingSpacesStripper.OVERRIDE_STRIP_TRAILING_SPACES_KEY,
+                                   trimTrailingWhitespaceKey, trimTrailingWhitespace, trimMap);
+        // Apply final newline setting
+        final String insertFinalNewline = Utils.configValueForKey(outPairs, insertFinalNewlineKey);
+        applyConfigValueToUserData(file, TrailingSpacesStripper.OVERRIDE_ENSURE_NEWLINE_KEY,
+                                   insertFinalNewlineKey, insertFinalNewline, newlineMap);
+    }
+
+    private static <T> void applyConfigValueToUserData(VirtualFile file, Key<T> userDataKey, String editorConfigKey,
+                                                       String configValue, Map<String, T> configMap) {
+        if (configValue.isEmpty()) {
+            file.putUserData(userDataKey, null);
+        } else {
+            final T data = configMap.get(configValue);
+            if (data == null) {
+                LOG.warn(Utils.invalidConfigMessage(configValue, editorConfigKey, file.getCanonicalPath()));
+            } else {
+                file.putUserData(userDataKey, data);
+                LOG.debug("Applied " + editorConfigKey + " settings for: " + file.getCanonicalPath());
+            }
+        }
+    }
+}

--- a/src/org/editorconfig/configmanagement/EncodingManager.java
+++ b/src/org/editorconfig/configmanagement/EncodingManager.java
@@ -51,7 +51,7 @@ public class EncodingManager extends FileDocumentManagerAdapter {
     }
 
     private void applySettings(VirtualFile file) {
-        if (!file.isInLocalFileSystem()) return;
+        if (file == null || !file.isInLocalFileSystem()) return;
         // Prevent "setEncoding" calling "saveAll" from causing an endless loop
         isApplyingSettings = true;
         final String filePath = file.getCanonicalPath();

--- a/src/org/editorconfig/configmanagement/LineEndingsManager.java
+++ b/src/org/editorconfig/configmanagement/LineEndingsManager.java
@@ -1,0 +1,94 @@
+package org.editorconfig.configmanagement;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.IdeFrame;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.WindowManager;
+import com.intellij.openapi.wm.impl.status.LineSeparatorPanel;
+import com.intellij.util.LineSeparator;
+import org.editorconfig.Utils;
+import org.editorconfig.core.EditorConfig;
+import org.editorconfig.plugincomponents.SettingsProviderComponent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author Dennis.Ushakov
+ */
+public class LineEndingsManager extends FileDocumentManagerAdapter {
+    // Handles the following EditorConfig settings:
+    private static final String lineEndingsKey = "end_of_line";
+
+    private final Logger LOG = Logger.getInstance("#org.editorconfig.codestylesettings.LineEndingsManager");
+    private final Project project;
+    private boolean statusBarUpdated = false;
+
+    public LineEndingsManager(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void beforeAllDocumentsSaving() {
+        statusBarUpdated = false;
+    }
+
+    private void updateStatusBar() {
+        ApplicationManager.getApplication().invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                IdeFrame frame = WindowManager.getInstance().getIdeFrame(project);
+                StatusBar statusBar = frame.getStatusBar();
+                StatusBarWidget widget = statusBar != null ? statusBar.getWidget("LineSeparator") : null;
+
+                if (widget instanceof LineSeparatorPanel) {
+                    FileEditorManagerEvent event = new FileEditorManagerEvent(FileEditorManager.getInstance(project),
+                                                                              null, null, null, null);
+                    ((LineSeparatorPanel)widget).selectionChanged(event);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void beforeDocumentSaving(@NotNull Document document) {
+        VirtualFile file = FileDocumentManager.getInstance().getFile(document);
+        applySettings(file);
+    }
+
+    private void applySettings(VirtualFile file) {
+        if (file == null || !file.isInLocalFileSystem()) return;
+
+        final String filePath = file.getCanonicalPath();
+        final List<EditorConfig.OutPair> outPairs = SettingsProviderComponent.getInstance().getOutPairs(filePath);
+        final String lineEndings = Utils.configValueForKey(outPairs, lineEndingsKey);
+        if (!lineEndings.isEmpty()) {
+            try {
+                LineSeparator separator = LineSeparator.valueOf(lineEndings.toUpperCase(Locale.US));
+                String oldSeparator = file.getDetectedLineSeparator();
+                String newSeparator = separator.getSeparatorString();
+                if (!StringUtil.equals(oldSeparator, newSeparator)) {
+                    file.setDetectedLineSeparator(newSeparator);
+                    if (!statusBarUpdated) {
+                        statusBarUpdated = true;
+                        updateStatusBar();
+                    }
+                    LOG.debug(Utils.appliedConfigMessage(lineEndings, lineEndingsKey, filePath));
+                }
+            } catch (IllegalArgumentException e) {
+                LOG.warn(Utils.invalidConfigMessage(lineEndings, lineEndingsKey, filePath));
+            }
+        }
+    }
+}

--- a/src/org/editorconfig/plugincomponents/ConfigProjectComponent.java
+++ b/src/org/editorconfig/plugincomponents/ConfigProjectComponent.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.wm.IdeFrame;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.util.messages.MessageBus;
 import org.editorconfig.configmanagement.CodeStyleManager;
+import org.editorconfig.configmanagement.EditorSettingsManager;
 import org.editorconfig.configmanagement.EncodingManager;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,9 +24,11 @@ public class ConfigProjectComponent implements ProjectComponent {
         // Register project-level config managers
         MessageBus bus = project.getMessageBus();
         codeStyleManager = new CodeStyleManager(project);
+        EditorSettingsManager editorSettingsManager = new EditorSettingsManager();
         EncodingManager encodingManager = new EncodingManager(project);
         bus.connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, codeStyleManager);
         bus.connect().subscribe(AppTopics.FILE_DOCUMENT_SYNC, encodingManager);
+        bus.connect().subscribe(AppTopics.FILE_DOCUMENT_SYNC, editorSettingsManager);
     }
 
     public void initComponent() {}

--- a/src/org/editorconfig/plugincomponents/ConfigProjectComponent.java
+++ b/src/org/editorconfig/plugincomponents/ConfigProjectComponent.java
@@ -10,6 +10,7 @@ import com.intellij.util.messages.MessageBus;
 import org.editorconfig.configmanagement.CodeStyleManager;
 import org.editorconfig.configmanagement.EditorSettingsManager;
 import org.editorconfig.configmanagement.EncodingManager;
+import org.editorconfig.configmanagement.LineEndingsManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
@@ -26,9 +27,11 @@ public class ConfigProjectComponent implements ProjectComponent {
         codeStyleManager = new CodeStyleManager(project);
         EditorSettingsManager editorSettingsManager = new EditorSettingsManager();
         EncodingManager encodingManager = new EncodingManager(project);
+        LineEndingsManager lineEndingsManager = new LineEndingsManager(project);
         bus.connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, codeStyleManager);
         bus.connect().subscribe(AppTopics.FILE_DOCUMENT_SYNC, encodingManager);
         bus.connect().subscribe(AppTopics.FILE_DOCUMENT_SYNC, editorSettingsManager);
+        bus.connect().subscribe(AppTopics.FILE_DOCUMENT_SYNC, lineEndingsManager);
     }
 
     public void initComponent() {}


### PR DESCRIPTION
This brings back end_of_line, trim_trailing_whitespace and insert_final_newline support. I would however postpone merging it until we publish new version with exception fixes and new java core
